### PR TITLE
Support pytest keyword filters

### DIFF
--- a/aws_infrastructure/aws_infrastructure/tasks/library/tests.py
+++ b/aws_infrastructure/aws_infrastructure/tasks/library/tests.py
@@ -16,14 +16,30 @@ class TestConfig:
     pipenv_pytest_dirs: List[Union[Path, str]]
 
 
-def _pipenv_pytest(*, context, test_dir: Path):
+def _pipenv_pytest(*, context, test_dir: Path, verbose: int, keyword: str):
     """
     Execute pytest within a Pipenv.
     """
 
     with context.cd(test_dir):
+        # Enforce a minimum verbosity of 1
+        verbose = verbose + 1
+        arg_verbose = "-{} ".format("v" * verbose)
+
+        # Pass through any keyword argument
+        arg_keyword = ""
+        if keyword:
+            arg_keyword = '-k "{}" '.format(keyword)
+
+        # Combine all args
+        command_args = "{}{}{}".format(
+            "-rsx ",  # Report (s)kipped and (f)ailed tests
+            arg_verbose,
+            arg_keyword,
+        )
+
         context.run(
-            command="pipenv run pytest -vv -rsx",
+            command="pipenv run pytest {}".format(command_args),
             # If multiple test sessions are to be executed,
             # continue despite a failure in this test session
             warn=True,
@@ -31,14 +47,19 @@ def _pipenv_pytest(*, context, test_dir: Path):
 
 
 def _task_test(*, test_name: str, test_config: TestConfig):
-    @task
-    def test(context):
+    @task(incrementable=["verbose"])
+    def test(context, verbose=0, keyword=None):
         """
         Execute {} tests.
         """
         if test_config.pipenv_pytest_dirs:
             for test_dir in test_config.pipenv_pytest_dirs:
-                _pipenv_pytest(context=context, test_dir=test_dir)
+                _pipenv_pytest(
+                    context=context,
+                    test_dir=test_dir,
+                    verbose=verbose,
+                    keyword=keyword,
+                )
 
     test.__doc__ = test.__doc__.format(test_name)
 


### PR DESCRIPTION
Allows commands like:

`invoke test.root -k semantics`

`invoke test.root -k "semantics and not set_id"`

`invoke test.root -v -k "semantics and not set_id"`
